### PR TITLE
added consideration for symbolic tensors to BroadcastTo

### DIFF
--- a/keras/src/layers/merging/concatenate.py
+++ b/keras/src/layers/merging/concatenate.py
@@ -145,12 +145,13 @@ class Concatenate(Merge):
                 # Input is unmasked. Append all 1s to masks,
                 masks.append(ops.ones_like(input_i, dtype="bool"))
             elif mask_i.ndim < input_i.ndim:
-                # Mask is smaller than the input, expand it
-                masks.append(
-                    ops.broadcast_to(
-                        ops.expand_dims(mask_i, axis=-1), ops.shape(input_i)
-                    )
+                # Broadcast mask shape to match in a way where we capture the
+                # input as a symbolic input in the op graph.
+                mask_i = ops.logical_or(
+                    ops.expand_dims(mask_i, axis=-1),
+                    ops.zeros_like(input_i, dtype="bool")
                 )
+                masks.append(mask_i)
             else:
                 masks.append(mask_i)
         concatenated = ops.concatenate(masks, axis=self.axis)

--- a/keras/src/layers/merging/merging_test.py
+++ b/keras/src/layers/merging/merging_test.py
@@ -340,6 +340,18 @@ class MergingLayersTest(testing.TestCase):
         )
         self.assertAllClose(output._keras_mask, [[1, 1, 1, 1]])
 
+    def test_concatenate_with_mask_symbolic(self):
+        input1 = layers.Input((4, 2))
+        input2 = layers.Input((4, 2))
+        mask = layers.Masking()
+        output = layers.Concatenate(axis=1)([mask(input1), input2])
+        model = models.Model(
+            inputs=[input1, input2], outputs=output._keras_mask
+        )
+        x1 = backend.convert_to_tensor([[[0, 0], [1, 2], [0, 0], [3, 4]]])
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [1, 2], [3, 4]]])
+        self.assertAllClose(model([x1, x2]), [[0, 1, 0, 1, 1, 1, 1, 1]])
+
     def test_concatenate_errors(self):
         # This should work
         x1 = np.ones((1, 1, 1, 1, 5))

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1780,12 +1780,14 @@ class BroadcastTo(Operation):
         self.shape = shape
 
     def call(self, x):
-        return backend.numpy.broadcast_to(x, self.shape)
+        # self.shape might be symbolic, so we determine it
+        output_shape = broadcast_shapes(x.shape, self.shape)
+        return backend.numpy.broadcast_to(x, output_shape)
 
     def compute_output_spec(self, x):
         # Catch broadcasting errors for clear error messages.
-        broadcast_shapes(x.shape, self.shape)
-        return KerasTensor(self.shape, dtype=x.dtype)
+        output_shape = broadcast_shapes(x.shape, self.shape)
+        return KerasTensor(output_shape, dtype=x.dtype)
 
 
 @keras_export(


### PR DESCRIPTION
This fixes the examples we discussed in the initial issue for jax backend (making the changes to `concatenate.py` redundant in this case). 
For tensorflow backend this only fixes the non-compiled variant that you added later on, while the compiled variant with fit is still broken.